### PR TITLE
fix: use a recursion identity to test if a type has already been looked at

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ test if a value is `Unknown`.
 - `Unknown`: We couldn't determine the immutability of the type.
 
 Note: `Calculating` is used internally to mean that we are still calculating the
-immutability of the type. You shouldn't every need to use this value.
+immutability of the type. You shouldn't ever need to use this value.
 
 ## Overrides
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ test if a value is `Unknown`.
 - `Mutable`: The data is shallowly mutable.
 - `Unknown`: We couldn't determine the immutability of the type.
 
-Note: Internally `Unknown` may also be used to mean that we are still
-calculating the immutability of the type. This shouldn't be exposed to the
-outside world though.
+Note: `Calculating` is used internally to mean that we are still calculating the
+immutability of the type. You shouldn't every need to use this value.
 
 ## Overrides
 

--- a/src/immutability.ts
+++ b/src/immutability.ts
@@ -10,4 +10,5 @@ export enum Immutability {
   ReadonlyShallow = 3,
   ReadonlyDeep = 4,
   Immutable = 5,
+  Calculating = Number.POSITIVE_INFINITY,
 }

--- a/tests/recursive.test.ts
+++ b/tests/recursive.test.ts
@@ -56,7 +56,7 @@ test("generics", (t) => {
   }
 
   for (const code of [
-    "type Test<G> = Readonly<{ foo: ReadonlyArray<Test<string>> | string; }>;",
+    "type Test<G> = Readonly<{ foo: ReadonlyArray<Test<string>> | G; }>;",
     "type Test<G> = G extends string ? ReadonlyArray<string> : Test<string>",
   ]) {
     runTestImmutability(
@@ -88,6 +88,17 @@ test("generics", (t) => {
       code,
       Immutability.Mutable,
       "handles generic recursive mutable types"
+    );
+  }
+});
+
+test("nested", (t) => {
+  for (const code of ["type Foo<U> = { readonly foo: Foo<Foo<U>>; };"]) {
+    runTestImmutability(
+      t,
+      code,
+      Immutability.Immutable,
+      "handles nested recursive immutable types"
     );
   }
 });

--- a/typings/typescript.d.ts
+++ b/typings/typescript.d.ts
@@ -12,16 +12,28 @@ declare module "typescript" {
      * - `readonly foo[]`
      */
     isArrayType(type: Type): type is TypeReference;
+
     /**
      * @returns `true` if the given type is a tuple type:
      * - `[foo]`
      * - `readonly [foo]`
      */
     isTupleType(type: Type): type is TupleTypeReference;
+
     /**
      * Return the type of the given property in the given type, or undefined if no such property exists
      */
     getTypeOfPropertyOfType(type: Type, propertyName: string): Type | undefined;
+
+    /**
+     * The recursion identity of a type is an object identity that is shared among multiple instantiations of the type.
+     * We track recursion identities in order to identify deeply nested and possibly infinite type instantiations with
+     * the same origin. For example, when type parameters are in scope in an object type such as { x: T }, all
+     * instantiations of that type have the same recursion identity. The default recursion identity is the object
+     * identity of the type, meaning that every type is unique. Generally, types with constituents that could circularly
+     * reference the type have a recursion identity that differs from the object identity.
+     */
+    getRecursionIdentity(type: Type): object;
   }
 
   interface Type {


### PR DESCRIPTION
fix #98