### PR TITLE
refactor!: expect the full program as an argument, not just the type checker

### DIFF
--- a/src/calculate.ts
+++ b/src/calculate.ts
@@ -64,11 +64,12 @@ const globalCache: ImmutabilityCache = new WeakMap();
  * Cache a type's immutability.
  */
 function cacheTypeImmutability(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   cache: ImmutabilityCache,
   type: Readonly<ts.Type>,
   value: Immutability
 ) {
+  const checker = program.getTypeChecker();
   const identity = checker.getRecursionIdentity(type);
   cache.set(identity, value);
 }
@@ -77,10 +78,11 @@ function cacheTypeImmutability(
  * Get a type's cashed immutability.
  */
 function getCachedTypeImmutability(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   cache: ImmutabilityCache,
   type: Readonly<ts.Type>
 ) {
+  const checker = program.getTypeChecker();
   const identity = checker.getRecursionIdentity(type);
   return cache.get(identity);
 }
@@ -91,7 +93,7 @@ function getCachedTypeImmutability(
  * If you only care about the immutability up to a certain point, a
  * `maxImmutability` can be specified to help improve performance.
  *
- * @param checker - The TypeScript Type Checker to use.
+ * @param program - The TypeScript Program to use.
  * @param typeOrTypeNode - The type to test the immutability of.
  * @param overrides - The overrides to use when calculating the immutability.
  * @param useCache - Either a custom cache to use, `true` to use the global
@@ -101,13 +103,13 @@ function getCachedTypeImmutability(
  * actual. This allows for early-escapes to be made in the type calculation.
  */
 export function getTypeImmutability(
-  checker: ts.TypeChecker,
-  // eslint-disable-next-line functional/prefer-immutable-types
+  program: ts.Program,
   typeOrTypeNode: ts.Type | ts.TypeNode,
   overrides: ImmutabilityOverrides = getDefaultOverrides(),
   useCache: ImmutabilityCache | boolean = true,
   maxImmutability = Immutability.Immutable
 ): Immutability {
+  const checker = program.getTypeChecker();
   const cache: ImmutabilityCache =
     useCache === true
       ? globalCache
@@ -118,25 +120,25 @@ export function getTypeImmutability(
   const type = isTypeNode(typeOrTypeNode)
     ? checker.getTypeFromTypeNode(typeOrTypeNode)
     : typeOrTypeNode;
-  const cached = getCachedTypeImmutability(checker, cache, type);
+  const cached = getCachedTypeImmutability(program, cache, type);
   if (cached !== undefined) {
     return cached;
   }
 
-  const override = getOverride(checker, typeOrTypeNode, overrides);
+  const override = getOverride(program, typeOrTypeNode, overrides);
   const overrideTo = override?.to;
   const overrideFrom = override?.from;
 
   // Early escape if we don't need to check the override from.
   if (overrideTo !== undefined && overrideFrom === undefined) {
-    cacheTypeImmutability(checker, cache, type, overrideTo);
+    cacheTypeImmutability(program, cache, type, overrideTo);
     return overrideTo;
   }
 
-  cacheTypeImmutability(checker, cache, type, Immutability.Calculating);
+  cacheTypeImmutability(program, cache, type, Immutability.Calculating);
 
   const immutability = calculateTypeImmutability(
-    checker,
+    program,
     type,
     overrides,
     cache,
@@ -149,12 +151,12 @@ export function getTypeImmutability(
       (overrideFrom <= immutability && immutability <= overrideTo) ||
       (overrideFrom >= immutability && immutability >= overrideTo)
     ) {
-      cacheTypeImmutability(checker, cache, type, overrideTo);
+      cacheTypeImmutability(program, cache, type, overrideTo);
       return overrideTo;
     }
   }
 
-  cacheTypeImmutability(checker, cache, type, immutability);
+  cacheTypeImmutability(program, cache, type, immutability);
   return immutability;
 }
 
@@ -162,7 +164,7 @@ export function getTypeImmutability(
  * Get the override for the type if it has one.
  */
 function getOverride(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   typeOrTypeNode: Readonly<ts.Type | ts.TypeNode>,
   overrides: ImmutabilityOverrides
 ) {
@@ -173,7 +175,7 @@ function getOverride(
     aliasWithArguments,
     evaluated,
     written,
-  } = typeToString(checker, typeOrTypeNode);
+  } = typeToString(program, typeOrTypeNode);
 
   for (const potentialOverride of overrides) {
     if (
@@ -201,7 +203,7 @@ function getOverride(
  * Calculated the immutability of the given type.
  */
 function calculateTypeImmutability(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   type: Readonly<ts.Type>,
   overrides: ImmutabilityOverrides,
   cache: ImmutabilityCache,
@@ -211,23 +213,24 @@ function calculateTypeImmutability(
   if (isUnionType(type)) {
     return type.types
       .map((t) =>
-        getTypeImmutability(checker, t, overrides, cache, maxImmutability)
+        getTypeImmutability(program, t, overrides, cache, maxImmutability)
       )
       .reduce(min);
   }
 
   // Intersection?
   if (isIntersectionType(type)) {
-    return objectImmutability(checker, type, overrides, cache, maxImmutability);
+    return objectImmutability(program, type, overrides, cache, maxImmutability);
   }
 
   // Conditional?
   if (isConditionalType(type)) {
+    const checker = program.getTypeChecker();
     return [type.root.node.trueType, type.root.node.falseType]
       .map((tn) => {
         const t = checker.getTypeFromTypeNode(tn);
         return getTypeImmutability(
-          checker,
+          program,
           t,
           overrides,
           cache,
@@ -245,23 +248,25 @@ function calculateTypeImmutability(
     return Immutability.Immutable;
   }
 
+  const checker = program.getTypeChecker();
+
   // Tuple?
   if (checker.isTupleType(type)) {
     if (!type.target.readonly) {
       return Immutability.Mutable;
     }
 
-    return arrayImmutability(checker, type, overrides, cache, maxImmutability);
+    return arrayImmutability(program, type, overrides, cache, maxImmutability);
   }
 
   // Array?
   if (checker.isArrayType(type)) {
-    return arrayImmutability(checker, type, overrides, cache, maxImmutability);
+    return arrayImmutability(program, type, overrides, cache, maxImmutability);
   }
 
   // Other type of object?
   if (isObjectType(type)) {
-    return objectImmutability(checker, type, overrides, cache, maxImmutability);
+    return objectImmutability(program, type, overrides, cache, maxImmutability);
   }
 
   // Must be a primitive.
@@ -272,14 +277,14 @@ function calculateTypeImmutability(
  * Get the immutability of the given array.
  */
 function arrayImmutability(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   type: Readonly<ts.TypeReference>,
   overrides: ImmutabilityOverrides,
   cache: ImmutabilityCache,
   maxImmutability: Immutability
 ): Immutability {
   const shallowImmutability = objectImmutability(
-    checker,
+    program,
     type,
     overrides,
     cache,
@@ -293,7 +298,7 @@ function arrayImmutability(
   }
 
   const deepImmutability = typeArgumentsImmutability(
-    checker,
+    program,
     type,
     overrides,
     cache,
@@ -311,12 +316,14 @@ function arrayImmutability(
  * Get the immutability of the given object.
  */
 function objectImmutability(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   type: Readonly<ts.Type>,
   overrides: ImmutabilityOverrides,
   cache: ImmutabilityCache,
   maxImmutability: Immutability
 ): Immutability {
+  const checker = program.getTypeChecker();
+
   let m_maxImmutability = maxImmutability;
   let m_minImmutability = Immutability.Mutable;
 
@@ -375,7 +382,7 @@ function objectImmutability(
       }
 
       const result = getTypeImmutability(
-        checker,
+        program,
         propertyType,
         overrides,
         cache,
@@ -390,7 +397,7 @@ function objectImmutability(
 
   if (isTypeReference(type)) {
     const result = typeArgumentsImmutability(
-      checker,
+      program,
       type,
       overrides,
       cache,
@@ -407,7 +414,7 @@ function objectImmutability(
   const stringIndexSigImmutability = types
     .map((t) =>
       indexSignatureImmutability(
-        checker,
+        program,
         t,
         ts.IndexKind.String,
         overrides,
@@ -425,7 +432,7 @@ function objectImmutability(
   const numberIndexSigImmutability = types
     .map((t) =>
       indexSignatureImmutability(
-        checker,
+        program,
         t,
         ts.IndexKind.Number,
         overrides,
@@ -447,17 +454,18 @@ function objectImmutability(
  * Get the immutability of the given type arguments.
  */
 function typeArgumentsImmutability(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   type: Readonly<ts.TypeReference>,
   overrides: ImmutabilityOverrides,
   cache: ImmutabilityCache,
   maxImmutability: Immutability
 ): Immutability {
+  const checker = program.getTypeChecker();
   const typeArguments = checker.getTypeArguments(type);
   if (typeArguments.length > 0) {
     return typeArguments
       .map((t) =>
-        getTypeImmutability(checker, t, overrides, cache, maxImmutability)
+        getTypeImmutability(program, t, overrides, cache, maxImmutability)
       )
       .reduce(min);
   }
@@ -469,13 +477,14 @@ function typeArgumentsImmutability(
  * Get the immutability of the given index signature.
  */
 function indexSignatureImmutability(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   type: Readonly<ts.Type>,
   kind: ts.IndexKind,
   overrides: ImmutabilityOverrides,
   cache: ImmutabilityCache,
   maxImmutability: Immutability
 ): Immutability {
+  const checker = program.getTypeChecker();
   const indexInfo = checker.getIndexInfoOfType(type, kind);
   if (indexInfo === undefined) {
     return Immutability.Unknown;
@@ -493,7 +502,7 @@ function indexSignatureImmutability(
     return max(
       Immutability.ReadonlyShallow,
       getTypeImmutability(
-        checker,
+        program,
         indexInfo.type,
         overrides,
         cache,

--- a/src/is.ts
+++ b/src/is.ts
@@ -17,20 +17,20 @@ import { Immutability } from "./immutability";
 /**
  * Is the immutability of the given type immutable.
  *
- * @param checker - The TypeScript Type Checker to use.
+ * @param program - The TypeScript Program to use.
  * @param typeOrTypeNode - The type to test the immutability of.
  * @param overrides - The overrides to use when calculating the immutability.
  * @param useCache - Either a custom cache to use, `true` to use the global
  * cache, or `false` to not use any predefined cache.
  */
 export function isImmutableType(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   typeOrTypeNode: Readonly<ts.Type | ts.TypeNode>,
   overrides: ImmutabilityOverrides = getDefaultOverrides(),
   useCache: ImmutabilityCache | boolean = true
 ) {
   const immutability = getTypeImmutability(
-    checker,
+    program,
     typeOrTypeNode,
     overrides,
     useCache,
@@ -42,20 +42,20 @@ export function isImmutableType(
 /**
  * Is the immutability of the given type at least readonly deep.
  *
- * @param checker - The TypeScript Type Checker to use.
+ * @param program - The TypeScript Program to use.
  * @param typeOrTypeNode - The type to test the immutability of.
  * @param overrides - The overrides to use when calculating the immutability.
  * @param useCache - Either a custom cache to use, `true` to use the global
  * cache, or `false` to not use any predefined cache.
  */
 export function isReadonlyDeepType(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   typeOrTypeNode: Readonly<ts.Type | ts.TypeNode>,
   overrides: ImmutabilityOverrides = getDefaultOverrides(),
   useCache: ImmutabilityCache | boolean = true
 ) {
   const immutability = getTypeImmutability(
-    checker,
+    program,
     typeOrTypeNode,
     overrides,
     useCache,
@@ -67,20 +67,20 @@ export function isReadonlyDeepType(
 /**
  * Is the immutability of the given type at least readonly shallow.
  *
- * @param checker - The TypeScript Type Checker to use.
+ * @param program - The TypeScript Program to use.
  * @param typeOrTypeNode - The type to test the immutability of.
  * @param overrides - The overrides to use when calculating the immutability.
  * @param useCache - Either a custom cache to use, `true` to use the global
  * cache, or `false` to not use any predefined cache.
  */
 export function isReadonlyShallowType(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   typeOrTypeNode: Readonly<ts.Type | ts.TypeNode>,
   overrides: ImmutabilityOverrides = getDefaultOverrides(),
   useCache: ImmutabilityCache | boolean = true
 ) {
   const immutability = getTypeImmutability(
-    checker,
+    program,
     typeOrTypeNode,
     overrides,
     useCache,
@@ -92,20 +92,20 @@ export function isReadonlyShallowType(
 /**
  * Is the immutability of the given type mutable.
  *
- * @param checker - The TypeScript Type Checker to use.
+ * @param program - The TypeScript Program to use.
  * @param typeOrTypeNode - The type to test the immutability of.
  * @param overrides - The overrides to use when calculating the immutability.
  * @param useCache - Either a custom cache to use, `true` to use the global
  * cache, or `false` to not use any predefined cache.
  */
 export function isMutableType(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   typeOrTypeNode: Readonly<ts.Type | ts.TypeNode>,
   overrides: ImmutabilityOverrides = getDefaultOverrides(),
   useCache: ImmutabilityCache | boolean = true
 ) {
   const immutability = getTypeImmutability(
-    checker,
+    program,
     typeOrTypeNode,
     overrides,
     useCache,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,8 +28,7 @@ export function isTypeNode(
  * Get string representations of the given type.
  */
 export function typeToString(
-  checker: ts.TypeChecker,
-  // eslint-disable-next-line functional/prefer-immutable-types
+  program: ts.Program,
   typeOrTypeNode: ts.Type | ts.TypeNode
 ): {
   name: string | undefined;
@@ -39,6 +38,7 @@ export function typeToString(
   evaluated: string;
   written: string | undefined;
 } {
+  const checker = program.getTypeChecker();
   const typeIsTypeNode = isTypeNode(typeOrTypeNode);
   const type = typeIsTypeNode
     ? checker.getTypeFromTypeNode(typeOrTypeNode)
@@ -58,7 +58,7 @@ export function typeToString(
     aliasType?.aliasTypeArguments === undefined
       ? undefined
       : typeArgumentsToString(
-          checker,
+          program,
           aliasType,
           alias,
           aliasType.aliasTypeArguments
@@ -93,7 +93,7 @@ export function typeToString(
       wrapperType?.typeArguments === undefined
         ? undefined
         : typeArgumentsToString(
-            checker,
+            program,
             checker.getTypeFromTypeNode(wrapperType),
             wrapperName,
             wrapperType.typeArguments.map((node) =>
@@ -124,7 +124,7 @@ export function typeToString(
 
   const nameWithArguments =
     typeArguments !== undefined && typeArguments.length > 0
-      ? `${name}<${typeArgumentsToString(checker, type, name, typeArguments)}>`
+      ? `${name}<${typeArgumentsToString(program, type, name, typeArguments)}>`
       : undefined;
 
   return {
@@ -141,7 +141,7 @@ export function typeToString(
  * Get string representations of the given type arguments.
  */
 function typeArgumentsToString(
-  checker: ts.TypeChecker,
+  program: ts.Program,
   type: Readonly<ts.Type>,
   typeName: string | undefined,
   typeArguments: ReadonlyArray<ts.Type>
@@ -150,7 +150,7 @@ function typeArgumentsToString(
     if (type === t) {
       return typeName;
     }
-    const strings = typeToString(checker, t);
+    const strings = typeToString(program, t);
     return strings.nameWithArguments ?? strings.name ?? strings.evaluated;
   });
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -72,7 +72,7 @@ function getType(code: string, line?: number) {
   return {
     type,
     typeNode: hasTypeNode(statement) ? statement.type : undefined,
-    checker,
+    program,
   };
 }
 
@@ -97,30 +97,30 @@ export function runTestImmutability(
       ? { code: test, line: undefined, overrides: undefined, cache: undefined }
       : test;
 
-  const { checker, type, typeNode } = getType(code, line);
+  const { program, type, typeNode } = getType(code, line);
 
   const actual = getTypeImmutability(
-    checker,
+    program,
     typeNode ?? type,
     overrides,
     cache
   );
   t.is(Immutability[actual], Immutability[expected], message);
 
-  const immutable = isImmutableType(checker, type, overrides, cache);
+  const immutable = isImmutableType(program, type, overrides, cache);
   t.is(expected >= Immutability.Immutable, immutable);
 
-  const readonlyDeep = isReadonlyDeepType(checker, type, overrides, cache);
+  const readonlyDeep = isReadonlyDeepType(program, type, overrides, cache);
   t.is(expected >= Immutability.ReadonlyDeep, readonlyDeep);
 
   const readonlyShallow = isReadonlyShallowType(
-    checker,
+    program,
     type,
     overrides,
     cache
   );
   t.is(expected >= Immutability.ReadonlyShallow, readonlyShallow);
 
-  const mutable = isMutableType(checker, type, overrides, cache);
+  const mutable = isMutableType(program, type, overrides, cache);
   t.is(expected === Immutability.Mutable, mutable);
 }


### PR DESCRIPTION
Having access to the `Program` gives us more info that just `Checker`.
We're not currently using this extra information, but it is there if we need it in future.

The new utils coming in `@typescript-eslint/type-utils` v6 that we want to leverage (re #47) will need the full Program.