### PR TITLE
fix: add eslint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "typescript": "5.0.2"
   },
   "peerDependencies": {
+    "eslint": "*",
     "typescript": ">=4.7.4"
   },
   "packageManager": "pnpm@7.29.1"


### PR DESCRIPTION
Heya @RebeccaStevens 👋 

I came across a failure today using the latest version of `is-immutable-type`. The error I'm seeing is...

```
Error: Failed to load plugin 'functional' declared in '.eslintrc.yaml: @typescript-eslint/utils tried to access eslint (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.

Ancestor breaking the chain: is-immutable-type@virtual:70e606d793a68f6d5ac8f179319747e564fc924037237be74fff4bbb6ce36b5e8b636187db8c67894f0f57a502240a521a7b4a32773fe8e04e73ed8177df26a3#npm:1.2.8

Require stack:
- /home/runner/work/.yarn/__virtual__/@typescript-eslint-utils-virtual-b0c1453e8c/0/cache/@typescript-eslint-utils-npm-5.55.0-6a927fceb5-368cfc3fb9.zip/node_modules/@typescript-eslint/utils/dist/eslint-utils/rule-tester/RuleTester.js
- /home/runner/work/.yarn/__virtual__/@typescript-eslint-utils-virtual-b0c1453e8c/0/cache/@typescript-eslint-utils-npm-5.55.0-6a927fceb5-368cfc3fb9.zip/node_modules/@typescript-eslint/utils/dist/eslint-utils/index.js
- /home/runner/work/.yarn/__virtual__/@typescript-eslint-utils-virtual-b0c1453e8c/0/cache/@typescript-eslint-utils-npm-5.55.0-6a927fceb5-368cfc3fb9.zip/node_modules/@typescript-eslint/utils/dist/index.js
- /home/runner/work/.yarn/__virtual__/@typescript-eslint-type-utils-virtual-b80c26ad18/0/cache/@typescript-eslint-type-utils-npm-5.55.0-333e5c4b16-5c60d44135.zip/node_modules/@typescript-eslint/type-utils/dist/isTypeReadonly.js
- /home/runner/work/.yarn/__virtual__/@typescript-eslint-type-utils-virtual-b80c26ad18/0/cache/@typescript-eslint-type-utils-npm-5.55.0-333e5c4b16-5c60d44135.zip/node_modules/@typescript-eslint/type-utils/dist/index.js
- /home/runner/work/.yarn/__virtual__/is-immutable-type-virtual-62dab2f0bc/0/cache/is-immutable-type-npm-1.2.8-1772ec013d-3375514a99.zip/node_modules/is-immutable-type/dist/index.cjs
- /home/runner/work/.yarn/__virtual__/eslint-plugin-functional-virtual-70e606d793/0/cache/eslint-plugin-functional-npm-5.0.6-fa1c7d009b-4f88008d53.zip/node_modules/eslint-plugin-functional/lib/index.js
- /home/runner/work/.yarn/cache/@eslint-eslintrc-npm-2.0.1-a51f526c2a-56b9192a68.zip/node_modules/@eslint/eslintrc/dist/eslintrc.cjs
    at require$$0.Module._resolveFilename (/home/runner/work/.pnp.cjs:32558:13)
    at require$$0.Module._load (/home/runner/work/.pnp.cjs:32408:42)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/home/runner/work/.yarn/__virtual__/@typescript-eslint-utils-virtual-b0c1453e8c/0/cache/@typescript-eslint-utils-npm-5.55.0-6a927fceb5-368cfc3fb9.zip/node_modules/@typescript-eslint/utils/dist/eslint-utils/rule-tester/RuleTester.js:54:24)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at require$$0.Module._extensions..js (/home/runner/work/.pnp.cjs:32602:33)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at require$$0.Module._load (/home/runner/work/.pnp.cjs:32439:14)
```

This is using the Plug'n'Play node linker (available from both yarn and pnpm).

I think the issue was introduced in #103. Since `@typescript-eslint/utils` is now a dependency, `is-immutable-type` needs to declare `eslint` as a dependency for it to be accessed via the stricter pnp node linker.

I added a peer dependency on `"eslint": "*"`, which is the same way `@typescript-eslint/type-utils` declares its dependency on `eslint`.