### PR TITLE
perf: switch to using an iterative stack

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -349,3 +349,10 @@ function qualifiedNameToString(qualifiedName: ts.QualifiedName): string {
     qualifiedName.right,
   )}`;
 }
+
+/**
+ * Cast the type.
+ */
+export function cast<T extends U, U = unknown>(value: U): value is T {
+  return true;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { isIntrinsicErrorType } from "ts-api-utils";
+import { isIntrinsicErrorType, isTypeReference } from "ts-api-utils";
 import ts from "typescript";
 
 import { typeToString, type TypeName } from "./type-to-string";
@@ -351,8 +351,25 @@ function qualifiedNameToString(qualifiedName: ts.QualifiedName): string {
 }
 
 /**
- * Cast the type.
+ * Is type a (non-namespace) function?
  */
-export function cast<T extends U, U = unknown>(value: U): value is T {
-  return true;
+export function isFunction(type: ts.Type) {
+  return (
+    type.getCallSignatures().length > 0 && type.getProperties().length === 0
+  );
+}
+
+/**
+ * Is type a type reference with type arguments?
+ */
+export function isTypeReferenceWithTypeArguments(
+  type: ts.Type,
+): type is ts.TypeReference & {
+  typeArguments: NonNullable<ts.TypeReference["typeArguments"]>;
+} {
+  return (
+    isTypeReference(type) &&
+    type.typeArguments !== undefined &&
+    type.typeArguments.length > 0
+  );
 }


### PR DESCRIPTION
Re: https://github.com/eslint-functional/eslint-plugin-functional/issues/767

Should hopefully fix stack overflow issues when analyzing large complex types.

It probably won't fix all stack overflow errors as I believe some are caused by the loop never terminating. More investigation is needed.