### PR TITLE
perf!: simplify how type are converted to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
   "dependencies": {
     "@typescript-eslint/type-utils": "^7.2.0",
     "ts-api-utils": "^1.3.0",
-    "ts-declaration-location": "^1.0.0",
-    "type-to-string": "^2.0.0"
+    "ts-declaration-location": "^1.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.2.1",
@@ -123,7 +122,7 @@
     "tsc-files": "1.1.4",
     "typescript": "5.4.3",
     "vite-tsconfig-paths": "4.3.2",
-    "vitest": "1.4.0"
+    "vitest": "1.5.0"
   },
   "peerDependencies": {
     "eslint": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ dependencies:
   ts-declaration-location:
     specifier: ^1.0.0
     version: 1.0.0(typescript@5.4.3)
-  type-to-string:
-    specifier: ^2.0.0
-    version: 2.0.0(ts-api-utils@1.3.0)(typescript@5.4.3)
 
 devDependencies:
   '@commitlint/cli':
@@ -69,7 +66,7 @@ devDependencies:
     version: 1.5.0
   '@vitest/coverage-v8':
     specifier: 1.4.0
-    version: 1.4.0(vitest@1.4.0)
+    version: 1.4.0(vitest@1.5.0)
   commitizen:
     specifier: 4.3.0
     version: 4.3.0(@types/node@20.12.2)(typescript@5.4.3)
@@ -129,7 +126,7 @@ devDependencies:
     version: 51.0.1(eslint@8.57.0)
   eslint-plugin-vitest:
     specifier: 0.4.1
-    version: 0.4.1(@typescript-eslint/eslint-plugin@7.4.0)(eslint@8.57.0)(typescript@5.4.3)(vitest@1.4.0)
+    version: 0.4.1(@typescript-eslint/eslint-plugin@7.4.0)(eslint@8.57.0)(typescript@5.4.3)(vitest@1.5.0)
   husky:
     specifier: 9.0.11
     version: 9.0.11
@@ -176,8 +173,8 @@ devDependencies:
     specifier: 4.3.2
     version: 4.3.2(typescript@5.4.3)
   vitest:
-    specifier: 1.4.0
-    version: 1.4.0(@types/node@20.12.2)
+    specifier: 1.5.0
+    version: 1.5.0(@types/node@20.12.2)
 
 packages:
 
@@ -1953,7 +1950,7 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@vitest/coverage-v8@1.4.0(vitest@1.4.0):
+  /@vitest/coverage-v8@1.4.0(vitest@1.5.0):
     resolution: {integrity: sha512-4hDGyH1SvKpgZnIByr9LhGgCEuF9DKM34IBLCC/fVfy24Z3+PZ+Ii9hsVBsHvY1umM1aGPEjceRkzxCfcQ10wg==}
     peerDependencies:
       vitest: 1.4.0
@@ -1972,43 +1969,43 @@ packages:
       strip-literal: 2.0.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.4.0(@types/node@20.12.2)
+      vitest: 1.5.0(@types/node@20.12.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitest/expect@1.4.0:
-    resolution: {integrity: sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==}
+  /@vitest/expect@1.5.0:
+    resolution: {integrity: sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==}
     dependencies:
-      '@vitest/spy': 1.4.0
-      '@vitest/utils': 1.4.0
+      '@vitest/spy': 1.5.0
+      '@vitest/utils': 1.5.0
       chai: 4.4.1
     dev: true
 
-  /@vitest/runner@1.4.0:
-    resolution: {integrity: sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==}
+  /@vitest/runner@1.5.0:
+    resolution: {integrity: sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==}
     dependencies:
-      '@vitest/utils': 1.4.0
+      '@vitest/utils': 1.5.0
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
 
-  /@vitest/snapshot@1.4.0:
-    resolution: {integrity: sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==}
+  /@vitest/snapshot@1.5.0:
+    resolution: {integrity: sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==}
     dependencies:
       magic-string: 0.30.8
       pathe: 1.1.2
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.4.0:
-    resolution: {integrity: sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==}
+  /@vitest/spy@1.5.0:
+    resolution: {integrity: sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==}
     dependencies:
       tinyspy: 2.2.1
     dev: true
 
-  /@vitest/utils@1.4.0:
-    resolution: {integrity: sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==}
+  /@vitest/utils@1.5.0:
+    resolution: {integrity: sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -3630,7 +3627,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-vitest@0.4.1(@typescript-eslint/eslint-plugin@7.4.0)(eslint@8.57.0)(typescript@5.4.3)(vitest@1.4.0):
+  /eslint-plugin-vitest@0.4.1(@typescript-eslint/eslint-plugin@7.4.0)(eslint@8.57.0)(typescript@5.4.3)(vitest@1.5.0):
     resolution: {integrity: sha512-+PnZ2u/BS+f5FiuHXz4zKsHPcMKHie+K+1Uvu/x91ovkCMEOJqEI8E9Tw1Wzx2QRz4MHOBHYf1ypO8N1K0aNAA==}
     engines: {node: ^18.0.0 || >= 20.0.0}
     peerDependencies:
@@ -3646,7 +3643,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 7.4.0(@typescript-eslint/parser@7.4.0)(eslint@8.57.0)(typescript@5.4.3)
       '@typescript-eslint/utils': 7.4.0(eslint@8.57.0)(typescript@5.4.3)
       eslint: 8.57.0
-      vitest: 1.4.0(@types/node@20.12.2)
+      vitest: 1.5.0(@types/node@20.12.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7133,8 +7130,8 @@ packages:
     resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
     dev: true
 
-  /tinypool@0.8.2:
-    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
+  /tinypool@0.8.3:
+    resolution: {integrity: sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -7293,16 +7290,6 @@ packages:
     resolution: {integrity: sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==}
     engines: {node: '>=16'}
     dev: true
-
-  /type-to-string@2.0.0(ts-api-utils@1.3.0)(typescript@5.4.3):
-    resolution: {integrity: sha512-tQhiWuq8+FkAYEAQ+Po1VPwzUhPVOXupzsVxZ/n9hN6oP92KXOpf4CFX0wclYa7QsrP4eBUIMydYJyv3ttRVRA==}
-    peerDependencies:
-      ts-api-utils: '>=1.3.0'
-      typescript: '>=5.0.0'
-    dependencies:
-      ts-api-utils: 1.3.0(typescript@5.4.3)
-      typescript: 5.4.3
-    dev: false
 
   /typed-array-buffer@1.0.2:
     resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
@@ -7499,8 +7486,8 @@ packages:
       semver: 7.6.0
     dev: true
 
-  /vite-node@1.4.0(@types/node@20.12.2):
-    resolution: {integrity: sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==}
+  /vite-node@1.5.0(@types/node@20.12.2):
+    resolution: {integrity: sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -7572,15 +7559,15 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.4.0(@types/node@20.12.2):
-    resolution: {integrity: sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==}
+  /vitest@1.5.0(@types/node@20.12.2):
+    resolution: {integrity: sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.4.0
-      '@vitest/ui': 1.4.0
+      '@vitest/browser': 1.5.0
+      '@vitest/ui': 1.5.0
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -7598,11 +7585,11 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.12.2
-      '@vitest/expect': 1.4.0
-      '@vitest/runner': 1.4.0
-      '@vitest/snapshot': 1.4.0
-      '@vitest/spy': 1.4.0
-      '@vitest/utils': 1.4.0
+      '@vitest/expect': 1.5.0
+      '@vitest/runner': 1.5.0
+      '@vitest/snapshot': 1.5.0
+      '@vitest/spy': 1.5.0
+      '@vitest/utils': 1.5.0
       acorn-walk: 8.3.2
       chai: 4.4.1
       debug: 4.3.4
@@ -7614,9 +7601,9 @@ packages:
       std-env: 3.7.0
       strip-literal: 2.0.0
       tinybench: 2.6.0
-      tinypool: 0.8.2
+      tinypool: 0.8.3
       vite: 5.1.6(@types/node@20.12.2)
-      vite-node: 1.4.0(@types/node@20.12.2)
+      vite-node: 1.5.0(@types/node@20.12.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/src/calculate.ts
+++ b/src/calculate.ts
@@ -344,9 +344,9 @@ function createApplyOverrideTaskState(
 function getOverride(parameters: Parameters, typeData: TypeData) {
   return parameters.overrides.find((potentialOverride) =>
     typeDataMatchesSpecifier(
-      typeData,
-      potentialOverride.type,
       parameters.program,
+      potentialOverride.type,
+      typeData,
     ),
   );
 }

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import { describe, it } from "vitest";
 
 import { Immutability, type ImmutabilityOverrides } from "#is-immutable-type";
@@ -38,31 +39,6 @@ describe("Overrides", () => {
         overrides: [
           {
             type: { from: "file", pattern: /^T.*/u },
-            to: Immutability.Immutable,
-          },
-        ],
-      },
-    ] as OverrideSet)("%s", ({ overrides }) => {
-      it.each(["type Test<G> = { foo: string };"])("Immutable", (code) => {
-        runTestImmutability({ code, overrides }, Immutability.Immutable);
-      });
-    });
-  });
-
-  describe("use type parameters in pattern of root override", () => {
-    describe.each([
-      {
-        overrides: [
-          {
-            type: /^Test<.+>/u,
-            to: Immutability.Immutable,
-          },
-        ],
-      },
-      {
-        overrides: [
-          {
-            type: { from: "file", pattern: /^Test<.+>/u },
             to: Immutability.Immutable,
           },
         ],
@@ -426,21 +402,27 @@ describe("Overrides", () => {
   });
 
   describe("Primitives", () => {
-    const code = `
-      type A = string;
-      type B = A;
-    `;
-
     it("overrids a primitive", () => {
       runTestImmutability(
-        { code, overrides: [{ type: "string", to: Immutability.Mutable }] },
+        {
+          code: dedent`
+            type A = string;
+          `,
+          overrides: [{ type: "string", to: Immutability.Mutable }],
+        },
         Immutability.Mutable,
       );
     });
 
     it("overrids a used alias of a primitive", () => {
       runTestImmutability(
-        { code, overrides: [{ type: "A", to: Immutability.Mutable }] },
+        {
+          code: dedent`
+            type A = string;
+            type B = A;
+          `,
+          overrides: [{ type: "A", to: Immutability.Mutable }],
+        },
         Immutability.Mutable,
       );
     });


### PR DESCRIPTION
BREAKING CHANGE: types aren't processed as much and thus not all override patterns are still
supported