### PR TITLE
fix: match overrides by canonical type-symbol name

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -277,6 +277,28 @@ export function defaultTypeMatchesPatternSpecifier(
     m_shouldInclude ||= include.some(testTypeNameName);
   }
 
+  // Source-spelling candidates (typeNode.getText(), the extracted generic
+  // head) miss when the type is reached via a qualified path, namespace, or
+  // `import("...").X` — none of those tokenize to the simple type name. Test
+  // the checker's canonical symbol name as well so e.g. `ns.Foo` matches an
+  // override on `Foo`.
+  const typeSymbolName = getTypeSymbolName(type);
+  if (
+    typeSymbolName !== null &&
+    typeSymbolName !== typeNameAlias &&
+    typeSymbolName !== typeNameName
+  ) {
+    const testTypeSymbolName = (pattern: string | RegExp) =>
+      typeof pattern === "string"
+        ? pattern === typeSymbolName
+        : pattern.test(typeSymbolName);
+
+    if (exclude.some(testTypeSymbolName)) {
+      return false;
+    }
+    m_shouldInclude ||= include.some(testTypeSymbolName);
+  }
+
   // Special handling for arrays not written in generic syntax.
   if (program.getTypeChecker().isArrayType(type) && typeNode !== null) {
     if (
@@ -304,6 +326,22 @@ export function defaultTypeMatchesPatternSpecifier(
   }
 
   return m_shouldInclude;
+}
+
+/**
+ * Get the canonical (leaf) symbol name of the given type — what you'd call
+ * the type if you ignored qualification, source spelling, and aliasing.
+ *
+ * Returns null for types with no usable symbol (intrinsic primitives,
+ * anonymous object literals whose symbol is the internal "__type", etc.).
+ */
+function getTypeSymbolName(type: ts.Type): string | null {
+  const target = "target" in type ? (type.target as ts.Type) : type;
+  const name = target.symbol?.getName();
+  if (name === undefined || name.startsWith("__")) {
+    return null;
+  }
+  return name;
 }
 
 /**

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -451,4 +451,49 @@ describe("Overrides", () => {
       );
     });
   });
+
+  describe("name matches regardless of how the type is spelled", () => {
+    const overrides = [
+      { type: "Foo", to: Immutability.ReadonlyShallow },
+    ] as ImmutabilityOverrides;
+
+    it("plain reference (baseline)", () => {
+      runTestImmutability(
+        {
+          code: dedent`
+            interface Foo { readonly bar: number; readonly baz(): void; }
+            type Test = Foo;
+          `,
+          overrides,
+        },
+        Immutability.ReadonlyShallow,
+      );
+    });
+
+    it("namespace-qualified reference", () => {
+      runTestImmutability(
+        {
+          code: dedent`
+            namespace ns { export interface Foo { readonly bar: number; readonly baz(): void; } }
+            type Test = ns.Foo;
+          `,
+          overrides,
+        },
+        Immutability.ReadonlyShallow,
+      );
+    });
+
+    it("nested namespace-qualified reference", () => {
+      runTestImmutability(
+        {
+          code: dedent`
+            namespace outer { export namespace inner { export interface Foo { readonly bar: number; readonly baz(): void; } } }
+            type Test = outer.inner.Foo;
+          `,
+          overrides,
+        },
+        Immutability.ReadonlyShallow,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Override name matching consulted `typeNode.getText()` and `typeToString` output but never the type's canonical symbol name, so a reference like `ns.Foo` or `import("node:fs").Stats` would not match `{ type: "Foo" }` / `{ name: "Stats" }` even though the underlying type IS `Foo` / `Stats`.
- Add the type's canonical symbol name (`target.symbol.getName()`, with `__`-prefixed internal symbols filtered out) as another candidate in `defaultTypeMatchesPatternSpecifier`, alongside the existing source-spelling, alias, and extracted-generic-head candidates. Qualified, namespaced, and `import()` spellings now all match an override on the leaf name.
