### PR TITLE
fix: report non-readonly index signatures as mutable when `maxImmutability` caps at `ReadonlyShallow`

### DIFF
--- a/src/calculate.ts
+++ b/src/calculate.ts
@@ -800,27 +800,27 @@ function createIndexSignatureTaskStates(
     return [];
   }
 
+  if (!indexInfo.isReadonly) {
+    mut_state.immutability = Immutability.Mutable;
+    return [];
+  }
+
   if (parameters.immutabilityLimits.max <= Immutability.ReadonlyShallow) {
     mut_state.immutability = Immutability.ReadonlyShallow;
     return [];
   }
 
-  if (indexInfo.isReadonly) {
-    if (indexInfo.type === typeData.type) {
-      mut_state.immutability = parameters.immutabilityLimits.max;
-      return [];
-    }
-
-    const child = createNewTaskState(
-      getTypeData(indexInfo.type, undefined), // TODO: can we get a type node for this?
-    );
-
-    return [
-      createChildrenReducerTaskState(mut_state, [{ immutability: Immutability.ReadonlyShallow }, child], max),
-      child,
-    ];
+  if (indexInfo.type === typeData.type) {
+    mut_state.immutability = parameters.immutabilityLimits.max;
+    return [];
   }
 
-  mut_state.immutability = Immutability.Mutable;
-  return [];
+  const child = createNewTaskState(
+    getTypeData(indexInfo.type, undefined), // TODO: can we get a type node for this?
+  );
+
+  return [
+    createChildrenReducerTaskState(mut_state, [{ immutability: Immutability.ReadonlyShallow }, child], max),
+    child,
+  ];
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -109,3 +109,31 @@ export function runTestImmutability(
     expect(expected).to.be.not.equal(Immutability.Mutable);
   }
 }
+
+/**
+ * Run tests against "getTypeImmutability" with a capped maximum immutability.
+ *
+ * Uses the resolved type rather than its type node, mirroring how consumers
+ * such as eslint-plugin-functional query immutability from the type checker.
+ */
+export function runTestImmutabilityCappedAt(
+  test:
+    | string
+    | Readonly<{
+        code: string;
+        line?: number;
+        overrides?: ImmutabilityOverrides;
+        cache?: ImmutabilityCache;
+      }>,
+  maxImmutability: Immutability,
+  expected: Immutability,
+  message?: string,
+): void {
+  const { code, line, overrides, cache } =
+    typeof test === "string" ? { code: test, line: undefined, overrides: undefined, cache: undefined } : test;
+
+  const { program, type } = getType(code, line);
+
+  const actual = getTypeImmutability(program, type, overrides, cache, maxImmutability);
+  expect(Immutability[actual]).to.be.equal(Immutability[expected], message);
+}

--- a/tests/index-signatures.test.ts
+++ b/tests/index-signatures.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "vitest";
+
+import { Immutability } from "#is-immutable-type";
+
+import { runTestImmutabilityCappedAt } from "./helpers";
+
+describe("Index Signatures", () => {
+  describe("capped at ReadonlyShallow", () => {
+    it.each(["type Test = Record<string, number>;", "type Test = { [key: string]: number };"])(
+      "reports a non-readonly index signature as Mutable",
+      (code) => {
+        runTestImmutabilityCappedAt(code, Immutability.ReadonlyShallow, Immutability.Mutable);
+      },
+    );
+
+    it.each(["type Test = { readonly [key: string]: number };"])(
+      "reports a readonly index signature as ReadonlyShallow",
+      (code) => {
+        runTestImmutabilityCappedAt(code, Immutability.ReadonlyShallow, Immutability.ReadonlyShallow);
+      },
+    );
+  });
+});


### PR DESCRIPTION
When `getTypeImmutability` is called with `maxImmutability = Immutability.ReadonlyShallow` (the common case from `eslint-plugin-functional`'s `prefer-immutable-types` rule), `createIndexSignatureTaskStates` short-circuits to `ReadonlyShallow` before consulting `indexInfo.isReadonly`. A non-readonly index signature such as `Record<string, number>` or `{ [k: string]: number }` is therefore reported as `ReadonlyShallow` instead of `Mutable`.

The fix consults `indexInfo.isReadonly` first: a non-readonly index signature is `Mutable` regardless of the cap, while a readonly one still resolves to at least `ReadonlyShallow` (capped as requested).

Reproduction (resolved `ts.Type`, the path consumers hit — the type-node path masked this):

```ts
type R = Record<string, number>;
type I = { [k: string]: number };
type RI = { readonly [k: string]: number };

getTypeImmutability(program, R, undefined, false, Immutability.ReadonlyShallow); // was ReadonlyShallow, now Mutable
getTypeImmutability(program, I, undefined, false, Immutability.ReadonlyShallow); // was ReadonlyShallow, now Mutable
getTypeImmutability(program, RI, undefined, false, Immutability.ReadonlyShallow); // ReadonlyShallow (the cap)
```

Downstream, this false negative let `eslint-plugin-functional`'s `prefer-immutable-types` rule silently accept parameters typed `Record<K, V>` or `{ [k: K]: V }` under `ReadonlyShallow` enforcement.

Covered by a new regression test in `tests/index-signatures.test.ts` exercising all three cases via the resolved type.