### PR TITLE
fix: resolve purely self-referential types as `Immutable` instead of `Unknown`

### DIFF
--- a/src/calculate.ts
+++ b/src/calculate.ts
@@ -275,10 +275,12 @@ function getTypeImmutabilityHelper(
     }
   } while (mut_stack.length > 0);
 
+  // A top-level result of `Calculating` means the type is purely
+  // self-referential: every constraint reduced to a recursive back-reference
+  // and none was concrete. Such a type is unconstrained, so it resolves to the
+  // top of the lattice rather than being reported as `Unknown`.
   if (mut_state.immutability === Immutability.Calculating) {
-    assert.fail('Tried to return immutability of "Calculating"');
-    // @ts-expect-error Unreachable Code
-    return Immutability.Unknown;
+    return Immutability.Immutable;
   }
   return mut_state.immutability;
 }

--- a/tests/conditionals.test.ts
+++ b/tests/conditionals.test.ts
@@ -23,4 +23,20 @@ describe("Conditionals", () => {
       runTestImmutability(code, Immutability.Immutable);
     },
   );
+
+  describe("recursive", () => {
+    it.each(["type Test<G> = G extends number ? Test<G> : Test<G>;"])(
+      "resolves to the lattice top when every branch is a recursive self-reference",
+      (code) => {
+        runTestImmutability(code, Immutability.Immutable);
+      },
+    );
+
+    it.each(["type Test<G> = G extends number ? Test<G> : readonly string[];"])(
+      "lets a non-recursive branch determine the immutability",
+      (code) => {
+        runTestImmutability(code, Immutability.ReadonlyDeep);
+      },
+    );
+  });
 });


### PR DESCRIPTION
A type whose immutability is determined solely by recursive back-references to itself reduces to the in-progress sentinel `Calculating` at the top level. The recursion guard caches `Calculating` (`POSITIVE_INFINITY`) for a type still on the stack; `min()` treats that sentinel as transparent so a concrete branch normally discards it. When *every* branch resolves to a back-reference there is no concrete branch to discard it, the top-level reduce stays `Calculating`, and the result surfaces as `Unknown` (the dev build asserts). A consumer hit this with a recursive conditional type over an unconstrained generic, where `Unknown` is unsatisfiable from user code.

A purely self-referential type carries no concrete constraint, so its greatest fixpoint is the top of the lattice. This returns `Immutable` in that terminal case, mirroring how recursive interfaces such as `interface I { readonly [key: string]: string | I }` already resolve, while leaving `Unknown` intact for genuinely indeterminate types. The fix is a single terminal check, so the existing `Calculating`-as-`+Infinity` flow through intermediate `min`/`max` reduces is untouched.

Regression coverage in `tests/conditionals.test.ts`: `type Test<G> = G extends number ? Test<G> : Test<G>` now resolves to `Immutable` (was `Unknown`), and a sibling `type Test<G> = G extends number ? Test<G> : readonly string[]` confirms a non-recursive branch still determines the result (`ReadonlyDeep`).