### PR TITLE
fix: 636

### DIFF
--- a/src/calculate.ts
+++ b/src/calculate.ts
@@ -594,6 +594,31 @@ function handleTypeIntersection(parameters: Parameters, mut_stack: Stack, mut_st
   handleTypeObject(parameters, mut_stack, mut_state);
 }
 
+function isPropertyInheritedFromPrimitiveIntersectionMember(
+  checker: ts.TypeChecker,
+  type: ts.IntersectionType,
+  property: ts.Symbol,
+): boolean {
+  return type.types.some(
+    (intersectionMember) =>
+      isPrimitiveType(intersectionMember) &&
+      checker.getApparentType(intersectionMember).getProperties().includes(property),
+  );
+}
+
+function isPrimitiveType(type: ts.Type): boolean {
+  const primitiveFlags =
+    ts.TypeFlags.StringLike |
+    ts.TypeFlags.NumberLike |
+    ts.TypeFlags.BigIntLike |
+    ts.TypeFlags.BooleanLike |
+    ts.TypeFlags.ESSymbolLike |
+    ts.TypeFlags.VoidLike |
+    ts.TypeFlags.Null;
+
+  return (type.flags & primitiveFlags) !== 0;
+}
+
 /**
  * Handle a type we know is a conditional type.
  */
@@ -689,6 +714,13 @@ function handleTypeObject(parameters: Parameters, mut_stack: Stack, mut_state: T
   const properties = mut_stateWithLimits.typeData.type.getProperties();
   if (properties.length > 0) {
     for (const property of properties) {
+      if (
+        isIntersectionType(mut_stateWithLimits.typeData.type) &&
+        isPropertyInheritedFromPrimitiveIntersectionMember(checker, mut_stateWithLimits.typeData.type, property)
+      ) {
+        continue;
+      }
+
       if (
         isPropertyReadonlyInType(mut_stateWithLimits.typeData.type, property.getEscapedName(), checker) ||
         // Ignore "length" for tuples.

--- a/tests/intersections.test.ts
+++ b/tests/intersections.test.ts
@@ -37,4 +37,31 @@ describe("Intersections", () => {
       runTestImmutability(code, Immutability.ReadonlyDeep);
     });
   });
+
+  describe("primitives", () => {
+    it.each(["string", "number", "boolean", "symbol", "bigint"])(
+      "treats %s intersected with an empty object as immutable",
+      (primitive) => {
+        runTestImmutability(`type Test = ${primitive} & {};`, Immutability.Immutable);
+      },
+    );
+
+    it("treats a readonly branded primitive as immutable", () => {
+      runTestImmutability(
+        `
+          declare const brand: unique symbol;
+          type Test = number & { readonly [brand]: true };
+        `,
+        Immutability.Immutable,
+      );
+    });
+
+    it("treats writable properties added to a primitive as mutable", () => {
+      runTestImmutability("type Test = number & { value: string };", Immutability.Mutable);
+    });
+
+    it("treats methods added to a primitive as readonly deep", () => {
+      runTestImmutability("type Test = number & { mutate(): void };", Immutability.ReadonlyDeep);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #636.

## Summary

- Treat properties inherited from primitive intersection members as primitive implementation details.
- Classify intersections such as `number & {}` and readonly branded primitives as `Immutable`.
- Preserve existing classifications for writable properties and methods added by other intersection members.

## Motivation

Primitive intersections are commonly used to preserve an alias in editor tooltips or create branded primitive types:

```ts
type int = number & {};
```

These types have no mutable state, but their inherited primitive methods caused them to be analyzed as `ReadonlyDeep` instead of `Immutable`.

The calculation now ignores a property only when the intersection inherited that exact property symbol from a primitive member. Properties contributed by another member are still analyzed normally, so writable properties remain `Mutable` and added methods remain `ReadonlyDeep`.

## Testing

- Added regression coverage for empty-object intersections with `string`, `number`, `boolean`, `symbol`, and `bigint`.
- Added coverage for readonly branded primitives.
- Added negative coverage for writable properties and methods added to primitive intersections.
- Ran the full test suite, type checking, and JavaScript/TypeScript linting.